### PR TITLE
Update Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,4 +27,4 @@ neo4j-driver = "*"
 pylint = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "*"


### PR DESCRIPTION
The latest Python version is `3.10. 0` but the pipenv requires Python 3.7. Making the changes now let it work on any version.